### PR TITLE
Update virtual_gifts_service.php

### DIFF
--- a/bol/virtual_gifts_service.php
+++ b/bol/virtual_gifts_service.php
@@ -308,7 +308,7 @@ final class VIRTUALGIFTS_BOL_VirtualGiftsService
      */
     public function getTemplateList( array $idList = null )
     {    
-        if ( count($idList) )
+        if ( !empty($idList) )
         {
             $tpls = $this->templateDao->findByIdList($idList);
         }


### PR DESCRIPTION
count() and by extension its alias sizeof() will fail with this usage in PHP 7 unlike empty()