### PR TITLE
Update virtual_gifts_service.php

### DIFF
--- a/bol/virtual_gifts_service.php
+++ b/bol/virtual_gifts_service.php
@@ -308,7 +308,7 @@ final class VIRTUALGIFTS_BOL_VirtualGiftsService
      */
     public function getTemplateList( array $idList = null )
     {    
-        if ( count($idList) )
+        if (!empty($idList) && count($idList) > 0)
         {
             $tpls = $this->templateDao->findByIdList($idList);
         }


### PR DESCRIPTION
On php 7.2  we get count(): Parameter must be an array or an object that implements Countable,  most likely due to $idList array being null so this will check to be sure it has value first